### PR TITLE
Update `tokio-rustls` to `0.23`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ hyper-h2 = ["hyper", "hyper/http2"]
 [dependencies]
 futures-util = "0.3.8"
 tokio = "1.0"
-tokio-rustls = "0.22.0"
+tokio-rustls = "0.23.0"
 pin-project = "1.0.2"
 #tokio-native-tls = "0.3.0"
 

--- a/examples/tls_config/mod.rs
+++ b/examples/tls_config/mod.rs
@@ -1,4 +1,4 @@
-use tokio_rustls::rustls::{Certificate, NoClientAuth, PrivateKey, ServerConfig};
+use tokio_rustls::rustls::{Certificate, PrivateKey, ServerConfig};
 
 const CERT: &[u8] = include_bytes!("local.cert");
 const PKEY: &[u8] = include_bytes!("local.key");
@@ -6,7 +6,10 @@ const PKEY: &[u8] = include_bytes!("local.key");
 pub fn tls_config() -> ServerConfig {
     let key = PrivateKey(PKEY.into());
     let cert = Certificate(CERT.into());
-    let mut config = ServerConfig::new(NoClientAuth::new());
-    config.set_single_cert(vec![cert], key).unwrap();
-    config
+
+    ServerConfig::builder()
+        .with_safe_defaults()
+        .with_no_client_auth()
+        .with_single_cert(vec![cert], key)
+        .unwrap()
 }


### PR DESCRIPTION
`tokio-rustls` changed `tokio_rustls::rustls::ServerConfig` and some APIs in version `0.23`, which caused some problems with this crate when using the new version of `tokio-rustls`