### PR TITLE
Make it so that TlsListener is Send when using native-tls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Upcoming release
+
+### Changed
+
+- The implementation of `AsyncTls` for `tokio_native_tls::TlsAcceptor` now requires the connection type to implement `Send`. This in turn allows `TlsListener` to be `Send` when using the `native-tls` feature. Technically, this is a breaking change. However, in practice it is unlikely to break existing code and makes using `TlsListener` much easier to use when `native-tls` is enabled.
+
 ## 0.4.0 - 2022-02-22
 
 NOTE: This release contains several breaking changes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,11 +191,11 @@ impl<C: AsyncRead + AsyncWrite + Unpin> AsyncTls<C> for tokio_rustls::TlsAccepto
 #[cfg(feature = "native-tls")]
 impl<C> AsyncTls<C> for tokio_native_tls::TlsAcceptor
 where
-    C: AsyncRead + AsyncWrite + Unpin + 'static,
+    C: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     type Stream = tokio_native_tls::TlsStream<C>;
     type Error = tokio_native_tls::native_tls::Error;
-    type AcceptFuture = Pin<Box<dyn Future<Output = Result<Self::Stream, Self::Error>>>>;
+    type AcceptFuture = Pin<Box<dyn Future<Output = Result<Self::Stream, Self::Error>> + Send>>;
 
     fn accept(&self, conn: C) -> Self::AcceptFuture {
         let tls = self.clone();


### PR DESCRIPTION
Unfortunately, I don't think this is backwards compatible.

Fixes: #9