### PR TITLE
Allow changing certificate at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.2 - 2022-04-09
+
+### Added
+
+- Added [TlsListener::replace_acceptor()] function to allow replacing the listener certificate at runtime.
+
 ## 0.4.1 - 2022-04-09
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tls-listener"
 description = "wrap incoming Stream of connections in TLS"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Thayne McCombs <astrothayne@gmail.com>"]
 repository = "https://github.com/tmccombs/tls-listener"
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,11 +17,11 @@
 use futures_util::stream::{FuturesUnordered, Stream, StreamExt};
 use pin_project_lite::pin_project;
 use std::future::Future;
-use std::io;
 use std::marker::Unpin;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
+use std::{io, mem};
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::time::{timeout, Timeout};
@@ -135,6 +135,13 @@ where
     /// This is essentially an alias to `self.next()` with a more domain-appropriate name.
     pub fn accept(&mut self) -> impl Future<Output = Option<<Self as Stream>::Item>> + '_ {
         self.next()
+    }
+
+    /// Replaces the Tls Acceptor configuration, which will be used for new connections.
+    ///
+    /// This can be used to change the certificate used at runtime.
+    pub fn replace_acceptor(&mut self, acceptor: T) {
+        self.tls = acceptor;
     }
 }
 


### PR DESCRIPTION
Hello again :)

One thing I would like to be able to do is replace the certificate dynamically / at runtime.

I have tested this myself using tokio select to accept both incoming connections, and reload certificate messages from a mpsc::channel

e.g. something along the lines of

```
tokio::select! {
            conn = listener.accept() => {
                match conn.expect("stream should be infinite") {
                    Ok(conn) => {
                        handle_connection(http.clone(), conn)
                    },
                    Err(e) => {
                        tracing::error!("Error receiving connection: {}", e);
                    }
                }
            },
            message = rx.recv() => {
               tracing::info!("reloading server certificate");
               listener.replace_acceptor(get_new_acceptor());
            }
        }
```