### PR TITLE
Add OpenSSL support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,11 @@ jobs:
           - tokio-net
           - rustls
           - native-tls
+          - openssl
           - rt
           - hyper-h1
           - hyper-h2
-          - rustls,native-tls
+          - rustls,native-tls,openssl
           - tokio-net,rt,rustls
           - tokio-net,native-tls
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## Upcoming 0.5.1
 
+### Added
+
+- Support for [`openssl`](https://github.com/sfackler/rust-openssl)
+
 ### Fixed
 
 - Fixed compilation on non-unix environments, where tokio-net doesn't include unix sockets
 - `SpawningHandshakes` will abort the tasks for pending connections when the linked futures are dropped. This should allow timeouts to cause the connectionto be closed.
-
 
 ## 0.5.0 - 2022-03-20
 
@@ -29,7 +32,7 @@
 
 ### Added
 
-- Added [TlsListener::replace_acceptor()] function to allow replacing the listener certificate at runtime.
+- Added `TlsListener::replace_acceptor()` function to allow replacing the listener certificate at runtime.
 
 ## 0.4.1 - 2022-03-09
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tls-listener"
 description = "wrap incoming Stream of connections in TLS"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Thayne McCombs <astrothayne@gmail.com>"]
 repository = "https://github.com/tmccombs/tls-listener"
 edition = "2018"
@@ -11,6 +11,7 @@ license = "Apache-2.0"
 default = ["tokio-net"]
 rustls = ["tokio-rustls"]
 native-tls = ["tokio-native-tls"]
+openssl = ["tokio-openssl", "openssl_impl"]
 rt = ["tokio/rt"]
 
 tokio-net = ["tokio/net"]
@@ -25,6 +26,8 @@ thiserror = "1.0.30"
 tokio = { version = "1.0", features = ["time"] }
 tokio-native-tls = { version = "0.3.0", optional = true }
 tokio-rustls = { version = "0.23.0", optional = true }
+tokio-openssl = { version = "0.6.3", optional = true }
+openssl_impl = { package = "openssl", version = "0.10.32", optional = true }
 
 [dev-dependencies]
 hyper = { version = "0.14.1", features = ["http1", "stream"] }
@@ -56,5 +59,5 @@ path = "examples/http-low-level.rs"
 required-features = ["hyper-h1"]
 
 [package.metadata.docs.rs]
-features = ["rustls", "native-tls", "hyper-h1", "hyper-h2"]
+features = ["rustls", "native-tls", "openssl", "hyper-h1", "hyper-h2", "rt"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ one of the `hyper-h1` or `hyper-h2` features).
 
 See examples for examples of usage.
 
-You must enable either one of the `rustls` or `native-tls` features depending on which implementation you would
-like to use.
+You must enable either one of the `rustls`, `native-tls`, or `openssl` features depending on which implementation you 
+would like to use.

--- a/examples/http-low-level.rs
+++ b/examples/http-low-level.rs
@@ -11,6 +11,8 @@ use std::convert::Infallible;
 mod tls_config;
 use tls_config::tls_acceptor;
 
+/// For example try:
+/// `curl https://localhost:3000 -k`
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     let addr = ([127, 0, 0, 1], 3000).into();


### PR DESCRIPTION
I just discovered native-tls doesn't support client certificate verification :(

https://github.com/sfackler/rust-native-tls/issues/161

So I need to use openssl instead, fortunately your trait design has made this very easy @tmccombs  :)

