### PR TITLE
deps: update tokio-rustls v0.23.0 -> v0.24.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,13 +25,19 @@ pin-project-lite = "0.2.8"
 thiserror = "1.0.30"
 tokio = { version = "1.0", features = ["time"] }
 tokio-native-tls = { version = "0.3.0", optional = true }
-tokio-rustls = { version = "0.23.0", optional = true }
+tokio-rustls = { version = "0.24.0", optional = true }
 tokio-openssl = { version = "0.6.3", optional = true }
 openssl_impl = { package = "openssl", version = "0.10.32", optional = true }
 
 [dev-dependencies]
 hyper = { version = "0.14.1", features = ["http1", "stream"] }
-tokio = { version = "1.0", features = ["rt", "macros", "net", "io-util", "signal"] }
+tokio = { version = "1.0", features = [
+    "rt",
+    "macros",
+    "net",
+    "io-util",
+    "signal",
+] }
 
 [[example]]
 name = "http"


### PR DESCRIPTION
depends on [tokio-rs/tls#137](https://github.com/tokio-rs/tls/pull/137)