### PR TITLE
feat!: Add a new error type for handshake timeouts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ hyper-h2 = ["hyper", "hyper/http2"]
 [dependencies]
 futures-util = "0.3.8"
 hyper = { version = "0.14.1", features = ["server", "tcp"], optional = true }
-pin-project-lite = "0.2.8"
+pin-project-lite = "0.2.13"
 thiserror = "1.0.30"
 tokio = { version = "1.0", features = ["time"] }
 tokio-native-tls = { version = "0.3.0", optional = true }

--- a/examples/echo-threads.rs
+++ b/examples/echo-threads.rs
@@ -13,7 +13,7 @@ mod tls_config;
 use tls_config::tls_acceptor;
 
 #[inline]
-async fn handle_stream(stream: TlsStream<TcpStream>) {
+async fn handle_stream(stream: TlsStream<TcpStream>, _remote_addr: SocketAddr) {
     let (mut reader, mut writer) = split(stream);
     match copy(&mut reader, &mut writer).await {
         Ok(cnt) => eprintln!("Processed {} bytes", cnt),
@@ -32,8 +32,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     TlsListener::new(SpawningHandshakes(tls_acceptor()), listener)
         .for_each_concurrent(None, |s| async {
             match s {
-                Ok(stream) => {
-                    handle_stream(stream).await;
+                Ok((stream, remote_addr)) => {
+                    handle_stream(stream, remote_addr).await;
                 }
                 Err(e) => {
                     eprintln!("Error: {:?}", e);

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     handle_stream(stream, remote_addr).await;
                 }
                 Err(e) => {
-                    if let Some(remote_addr) = e.remote_addr() {
+                    if let Some(remote_addr) = e.peer_addr() {
                         eprint!("[client {remote_addr}] ");
                     }
 

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -22,7 +22,7 @@ mod tls_config;
 use tls_config::tls_acceptor;
 
 #[inline]
-async fn handle_stream(stream: TlsStream<TcpStream>) {
+async fn handle_stream(stream: TlsStream<TcpStream>, _remote_addr: SocketAddr) {
     let (mut reader, mut writer) = split(stream);
     match copy(&mut reader, &mut writer).await {
         Ok(cnt) => eprintln!("Processed {} bytes", cnt),
@@ -41,10 +41,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     TlsListener::new(tls_acceptor(), listener)
         .for_each_concurrent(None, |s| async {
             match s {
-                Ok(stream) => {
-                    handle_stream(stream).await;
+                Ok((stream, remote_addr)) => {
+                    handle_stream(stream, remote_addr).await;
                 }
                 Err(e) => {
+                    if let Some(remote_addr) = e.remote_addr() {
+                        eprint!("[client {remote_addr}] ");
+                    }
+
                     eprintln!("Error accepting connection: {:?}", e);
                 }
             }

--- a/examples/http-change-certificate.rs
+++ b/examples/http-change-certificate.rs
@@ -37,12 +37,12 @@ async fn main() {
                         tokio::spawn(async move {
                             let svc = service_fn(move |request| handle_request(tx.clone(), counter.clone(), request));
                             if let Err(err) = http.serve_connection(conn, svc).await {
-                                eprintln!("Application error (client address: {remote_addr}): {}", err);
+                                eprintln!("Application error (client address: {remote_addr}): {err}");
                             }
                         });
                     },
                     Err(e) => {
-                        if let Some(remote_addr) = e.remote_addr() {
+                        if let Some(remote_addr) = e.peer_addr() {
                             eprint!("[client {remote_addr}] ");
                         }
 

--- a/examples/http-low-level.rs
+++ b/examples/http-low-level.rs
@@ -36,7 +36,7 @@ async fn main() {
                     });
                 }
                 Err(err) => {
-                    if let Some(remote_addr) = err.remote_addr() {
+                    if let Some(remote_addr) = err.peer_addr() {
                         eprint!("[client {remote_addr}] ");
                     }
 

--- a/examples/http-low-level.rs
+++ b/examples/http-low-level.rs
@@ -27,15 +27,19 @@ async fn main() {
     listener
         .for_each(|r| async {
             match r {
-                Ok(conn) => {
+                Ok((conn, remote_addr)) => {
                     let http = http.clone();
                     tokio::spawn(async move {
                         if let Err(err) = http.serve_connection(conn, svc).await {
-                            eprintln!("Application error: {}", err);
+                            eprintln!("[client {remote_addr}] Application error: {}", err);
                         }
                     });
                 }
                 Err(err) => {
+                    if let Some(remote_addr) = err.remote_addr() {
+                        eprint!("[client {remote_addr}] ");
+                    }
+
                     eprintln!("Error accepting connection: {}", err);
                 }
             }

--- a/examples/http-stream.rs
+++ b/examples/http-stream.rs
@@ -1,4 +1,4 @@
-use futures_util::stream::{StreamExt, TryStreamExt};
+use futures_util::stream::StreamExt;
 use hyper::server::accept;
 use hyper::server::conn::AddrIncoming;
 use hyper::service::{make_service_fn, service_fn};
@@ -23,6 +23,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // This uses a filter to handle errors with connecting
     let incoming = TlsListener::new(tls_acceptor(), AddrIncoming::bind(&addr)?)
+        .connections()
         .filter(|conn| {
             if let Err(err) = conn {
                 eprintln!("Error: {:?}", err);
@@ -30,8 +31,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             } else {
                 ready(true)
             }
-        })
-        .map_ok(|(conn, _remote_addr)| conn);
+        });
 
     let server = Server::builder(accept::from_stream(incoming)).serve(new_svc);
     server.await?;

--- a/examples/http-stream.rs
+++ b/examples/http-stream.rs
@@ -1,4 +1,4 @@
-use futures_util::stream::StreamExt;
+use futures_util::stream::{StreamExt, TryStreamExt};
 use hyper::server::accept;
 use hyper::server::conn::AddrIncoming;
 use hyper::service::{make_service_fn, service_fn};
@@ -22,14 +22,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     // This uses a filter to handle errors with connecting
-    let incoming = TlsListener::new(tls_acceptor(), AddrIncoming::bind(&addr)?).filter(|conn| {
-        if let Err(err) = conn {
-            eprintln!("Error: {:?}", err);
-            ready(false)
-        } else {
-            ready(true)
-        }
-    });
+    let incoming = TlsListener::new(tls_acceptor(), AddrIncoming::bind(&addr)?)
+        .filter(|conn| {
+            if let Err(err) = conn {
+                eprintln!("Error: {:?}", err);
+                ready(false)
+            } else {
+                ready(true)
+            }
+        })
+        .map_ok(|(conn, _remote_addr)| conn);
 
     let server = Server::builder(accept::from_stream(incoming)).serve(new_svc);
     server.await?;

--- a/examples/tls_config/mod.rs
+++ b/examples/tls_config/mod.rs
@@ -5,7 +5,9 @@ mod config {
 
     const CERT: &[u8] = include_bytes!("local.cert");
     const PKEY: &[u8] = include_bytes!("local.key");
+    #[allow(dead_code)]
     const CERT2: &[u8] = include_bytes!("local2.cert");
+    #[allow(dead_code)]
     const PKEY2: &[u8] = include_bytes!("local2.key");
 
     pub type Acceptor = tokio_rustls::TlsAcceptor;
@@ -27,6 +29,7 @@ mod config {
         tls_acceptor_impl(PKEY, CERT)
     }
 
+    #[allow(dead_code)]
     pub fn tls_acceptor2() -> Acceptor {
         tls_acceptor_impl(PKEY2, CERT2)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ use futures_util::stream::{FuturesUnordered, Stream, StreamExt};
 use pin_project_lite::pin_project;
 #[cfg(feature = "rt")]
 pub use spawning_handshake::SpawningHandshakes;
+use std::fmt::Debug;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -67,6 +68,11 @@ pub trait AsyncTls<C: AsyncRead + AsyncWrite>: Clone {
 pub trait AsyncAccept {
     /// The type of the connection that is accepted.
     type Connection: AsyncRead + AsyncWrite;
+    /// The type of the remote address, such as [`std::net::SocketAddr`].
+    ///
+    /// If no remote address can be determined (such as for mock connections),
+    /// `()` or a similar dummy type can be used.
+    type Address: Debug;
     /// The type of error that may be returned.
     type Error;
 
@@ -74,7 +80,7 @@ pub trait AsyncAccept {
     fn poll_accept(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Self::Connection, Self::Error>>>;
+    ) -> Poll<Option<Result<(Self::Connection, Self::Address), Self::Error>>>;
 
     /// Return a new `AsyncAccept` that stops accepting connections after
     /// `ender` completes.
@@ -126,7 +132,7 @@ pin_project! {
         #[pin]
         listener: A,
         tls: T,
-        waiting: FuturesUnordered<Timeout<T::AcceptFuture>>,
+        waiting: FuturesUnordered<FutureWithExtraData<Timeout<T::AcceptFuture>, A::Address>>,
         max_handshakes: usize,
         timeout: Duration,
     }
@@ -143,19 +149,35 @@ pub struct Builder<T> {
 /// Wraps errors from either the listener or the TLS Acceptor
 #[derive(Debug, Error)]
 #[non_exhaustive]
-pub enum Error<LE: std::error::Error, TE: std::error::Error> {
+// TODO: It would probably be more simple and more future-proof to use the
+// `AsyncAccept` and `AsyncTls` implementations as the type parameters here, so
+// that their associated types can be used in the fields
+// (i.e. `error: A::Error, remote_addr: A::Address`), but that would require us
+// to either hand-write `impl Debug` or use a proc-macro crate like
+// `impl-tools` to derive `Debug` with custom bounds,
+// due to https://github.com/rust-lang/rust/issues/26925
+pub enum Error<LE: std::error::Error, TE: std::error::Error, A> {
     /// An error that arose from the listener ([AsyncAccept::Error])
     #[error("{0}")]
     ListenerError(#[source] LE),
     /// An error that occurred during the TLS accept handshake
-    #[error("{0}")]
-    TlsAcceptError(#[source] TE),
-    // TODO: is there any way we could include thee original connection, or maybe some
-    // info about it here?
+    #[error("{error}")]
+    #[non_exhaustive]
+    TlsAcceptError {
+        /// The error that occurred.
+        #[source]
+        error: TE,
+
+        /// The client's address and port.
+        remote_addr: A,
+    },
     /// The TLS handshake timed out
     #[error("Timeout during TLS handshake")]
     #[non_exhaustive]
-    HandshakeTimeout {},
+    HandshakeTimeout {
+        /// The client's address and port.
+        remote_addr: A,
+    },
 }
 
 impl<A: AsyncAccept, T> TlsListener<A, T>
@@ -207,7 +229,7 @@ where
     A::Error: std::error::Error,
     T: AsyncTls<A::Connection>,
 {
-    type Item = Result<T::Stream, Error<A::Error, T::Error>>;
+    type Item = Result<(T::Stream, A::Address), Error<A::Error, T::Error, A::Address>>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
@@ -215,9 +237,11 @@ where
         while this.waiting.len() < *this.max_handshakes {
             match this.listener.as_mut().poll_accept(cx) {
                 Poll::Pending => break,
-                Poll::Ready(Some(Ok(conn))) => {
-                    this.waiting
-                        .push(timeout(*this.timeout, this.tls.accept(conn)));
+                Poll::Ready(Some(Ok((conn, address)))) => {
+                    this.waiting.push(FutureWithExtraData::new(
+                        timeout(*this.timeout, this.tls.accept(conn)),
+                        address,
+                    ));
                 }
                 Poll::Ready(Some(Err(e))) => {
                     return Poll::Ready(Some(Err(Error::ListenerError(e))));
@@ -227,10 +251,15 @@ where
         }
 
         match this.waiting.poll_next_unpin(cx) {
-            Poll::Ready(Some(Ok(conn))) => Poll::Ready(Some(conn.map_err(Error::TlsAcceptError))),
+            Poll::Ready(Some((Ok(result), remote_addr))) => Poll::Ready(Some(match result {
+                Ok(conn) => Ok((conn, remote_addr)),
+                Err(error) => Err(Error::TlsAcceptError { error, remote_addr }),
+            })),
             // The handshake timed out, try getting another connection from the
             // queue
-            Poll::Ready(Some(Err(_))) => Poll::Ready(Some(Err(Error::HandshakeTimeout()))),
+            Poll::Ready(Some((Err(_), remote_addr))) => {
+                Poll::Ready(Some(Err(Error::HandshakeTimeout { remote_addr })))
+            }
             _ => Poll::Pending,
         }
     }
@@ -337,6 +366,19 @@ impl<T> Builder<T> {
     }
 }
 
+impl<LE: std::error::Error, TE: std::error::Error, A> Error<LE, TE, A> {
+    /// Returns the client's address and port, if known.
+    pub fn remote_addr(&self) -> Option<&A> {
+        match self {
+            Self::ListenerError(_) => None,
+
+            Self::TlsAcceptError { remote_addr, .. } | Self::HandshakeTimeout { remote_addr } => {
+                Some(remote_addr)
+            }
+        }
+    }
+}
+
 /// Create a new Builder for a TlsListener
 ///
 /// `server_config` will be used to configure the TLS sessions.
@@ -361,16 +403,54 @@ pin_project! {
 impl<A: AsyncAccept, E: Future> AsyncAccept for Until<A, E> {
     type Connection = A::Connection;
     type Error = A::Error;
+    type Address = A::Address;
 
     fn poll_accept(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Self::Connection, Self::Error>>> {
+    ) -> Poll<Option<Result<(Self::Connection, Self::Address), Self::Error>>> {
         let this = self.project();
 
         match this.ender.poll(cx) {
             Poll::Pending => this.acceptor.poll_accept(cx),
             Poll::Ready(_) => Poll::Ready(None),
         }
+    }
+}
+
+pin_project! {
+    struct FutureWithExtraData<Fut, X> {
+        #[pin]
+        future: Fut,
+        extra: Option<X>,
+    }
+}
+
+impl<Fut, X> FutureWithExtraData<Fut, X> {
+    fn new(future: Fut, extra: X) -> Self {
+        Self {
+            future,
+            extra: Some(extra),
+        }
+    }
+}
+
+impl<Fut, X> Future for FutureWithExtraData<Fut, X>
+where
+    Fut: Future,
+{
+    type Output = (Fut::Output, X);
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let extra = this.extra;
+
+        this.future.poll(cx).map(|output| {
+            let extra = extra
+                .take()
+                .expect("this future has already been polled to completion");
+
+            (output, extra)
+        })
     }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -10,13 +10,14 @@ use tokio::net::{UnixListener, UnixStream};
 impl AsyncAccept for TcpListener {
     type Connection = TcpStream;
     type Error = io::Error;
+    type Address = std::net::SocketAddr;
 
     fn poll_accept(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Self::Connection, Self::Error>>> {
+    ) -> Poll<Option<Result<(Self::Connection, Self::Address), Self::Error>>> {
         match (*self).poll_accept(cx) {
-            Poll::Ready(Ok((stream, _))) => Poll::Ready(Some(Ok(stream))),
+            Poll::Ready(Ok((stream, remote_addr))) => Poll::Ready(Some(Ok((stream, remote_addr)))),
             Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
             Poll::Pending => Poll::Pending,
         }
@@ -28,13 +29,14 @@ impl AsyncAccept for TcpListener {
 impl AsyncAccept for UnixListener {
     type Connection = UnixStream;
     type Error = io::Error;
+    type Address = tokio::net::unix::SocketAddr;
 
     fn poll_accept(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Self::Connection, Self::Error>>> {
+    ) -> Poll<Option<Result<(Self::Connection, Self::Address), Self::Error>>> {
         match (*self).poll_accept(cx) {
-            Poll::Ready(Ok((stream, _))) => Poll::Ready(Some(Ok(stream))),
+            Poll::Ready(Ok((stream, remote_addr))) => Poll::Ready(Some(Ok((stream, remote_addr)))),
             Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
             Poll::Pending => Poll::Pending,
         }

--- a/src/net.rs
+++ b/src/net.rs
@@ -17,7 +17,7 @@ impl AsyncAccept for TcpListener {
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<(Self::Connection, Self::Address), Self::Error>>> {
         match (*self).poll_accept(cx) {
-            Poll::Ready(Ok((stream, remote_addr))) => Poll::Ready(Some(Ok((stream, remote_addr)))),
+            Poll::Ready(Ok(conn)) => Poll::Ready(Some(Ok(conn))),
             Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
             Poll::Pending => Poll::Pending,
         }
@@ -36,7 +36,7 @@ impl AsyncAccept for UnixListener {
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<(Self::Connection, Self::Address), Self::Error>>> {
         match (*self).poll_accept(cx) {
-            Poll::Ready(Ok((stream, remote_addr))) => Poll::Ready(Some(Ok((stream, remote_addr)))),
+            Poll::Ready(Ok(conn)) => Poll::Ready(Some(Ok(conn))),
             Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
             Poll::Pending => Poll::Pending,
         }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -69,7 +69,7 @@ async fn tls_error() {
     assert_err!(
         listener.accept().await.unwrap(),
         TlsAcceptError {
-            remote_addr: MockAddress(42),
+            peer_addr: MockAddress(42),
             ..
         }
     );
@@ -121,5 +121,20 @@ async fn echo() {
 
     if let Err(e) = listener.await {
         std::panic::resume_unwind(e.into_panic());
+    }
+}
+
+#[tokio::test]
+async fn addr() {
+    let (connector, mut listener) = setup();
+
+    spawn(async move {
+        connector.send_data(b"hi").await.unwrap();
+        connector.send_data(b"boo").await.unwrap();
+        connector.send_data(b"test").await.unwrap();
+    });
+
+    for i in 42..44 {
+        assert_eq!(listener.accept().await.unwrap().unwrap().1, MockAddress(i));
     }
 }

--- a/tests/helper/mocks.rs
+++ b/tests/helper/mocks.rs
@@ -2,7 +2,7 @@ use futures_util::future::{self, Ready};
 use futures_util::ready;
 use std::io;
 use std::pin::Pin;
-use std::sync::atomic::{self, AtomicU32};
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::task::{Context, Poll};
 use tokio::io::{
     duplex, split, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, DuplexStream, ReadBuf,
@@ -22,7 +22,7 @@ pub struct MockConnect {
     counter: AtomicU32,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct MockAddress(pub u32);
 
 pub fn accepting() -> (MockConnect, MockAccept) {
@@ -39,7 +39,7 @@ pub fn accepting() -> (MockConnect, MockAccept) {
 impl MockConnect {
     pub async fn connect(&self) -> DuplexStream {
         let (tx, rx) = duplex(1024);
-        let count = self.counter.fetch_add(1, atomic::Ordering::Relaxed);
+        let count = self.counter.fetch_add(1, Ordering::Relaxed);
         self.chan.send(Ok((rx, MockAddress(count)))).await.unwrap();
         tx
     }

--- a/tests/helper/mod.rs
+++ b/tests/helper/mod.rs
@@ -18,7 +18,7 @@ pub fn setup_echo() -> (MockConnect, JoinHandle<()>) {
     let (connector, listener) = setup();
 
     let handle = tokio::spawn(listener.for_each_concurrent(None, |s| async {
-        let (mut reader, mut writer) = split(s.expect("Unexpected error"));
+        let (mut reader, mut writer) = split(s.expect("Unexpected error").0);
         copy(&mut reader, &mut writer)
             .await
             .expect("Failed to copy");


### PR DESCRIPTION
And make the errors enun non_exhaustive

BREAKING CHANGE: Adds a new variant to the Error Enum
BREAKING CHANGE: The Error enum is now non_exhaustive
BREAKING CHANGE: Now returns an error if a handshake times out
Fixes: #36