### PR TITLE
#37, but also report the remote address

### DIFF
--- a/examples/echo-threads.rs
+++ b/examples/echo-threads.rs
@@ -13,7 +13,7 @@ mod tls_config;
 use tls_config::tls_acceptor;
 
 #[inline]
-async fn handle_stream(stream: TlsStream<TcpStream>) {
+async fn handle_stream(stream: TlsStream<TcpStream>, _remote_addr: SocketAddr) {
     let (mut reader, mut writer) = split(stream);
     match copy(&mut reader, &mut writer).await {
         Ok(cnt) => eprintln!("Processed {} bytes", cnt),
@@ -32,8 +32,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     TlsListener::new(SpawningHandshakes(tls_acceptor()), listener)
         .for_each_concurrent(None, |s| async {
             match s {
-                Ok(stream) => {
-                    handle_stream(stream).await;
+                Ok((stream, remote_addr)) => {
+                    handle_stream(stream, remote_addr).await;
                 }
                 Err(e) => {
                     eprintln!("Error: {:?}", e);

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -22,7 +22,7 @@ mod tls_config;
 use tls_config::tls_acceptor;
 
 #[inline]
-async fn handle_stream(stream: TlsStream<TcpStream>) {
+async fn handle_stream(stream: TlsStream<TcpStream>, _remote_addr: SocketAddr) {
     let (mut reader, mut writer) = split(stream);
     match copy(&mut reader, &mut writer).await {
         Ok(cnt) => eprintln!("Processed {} bytes", cnt),
@@ -41,10 +41,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     TlsListener::new(tls_acceptor(), listener)
         .for_each_concurrent(None, |s| async {
             match s {
-                Ok(stream) => {
-                    handle_stream(stream).await;
+                Ok((stream, remote_addr)) => {
+                    handle_stream(stream, remote_addr).await;
                 }
                 Err(e) => {
+                    if let Some(remote_addr) = e.remote_addr() {
+                        eprint!("[client {remote_addr}] ");
+                    }
+
                     eprintln!("Error accepting connection: {:?}", e);
                 }
             }

--- a/examples/http-low-level.rs
+++ b/examples/http-low-level.rs
@@ -27,15 +27,19 @@ async fn main() {
     listener
         .for_each(|r| async {
             match r {
-                Ok(conn) => {
+                Ok((conn, remote_addr)) => {
                     let http = http.clone();
                     tokio::spawn(async move {
                         if let Err(err) = http.serve_connection(conn, svc).await {
-                            eprintln!("Application error: {}", err);
+                            eprintln!("[client {remote_addr}] Application error: {}", err);
                         }
                     });
                 }
                 Err(err) => {
+                    if let Some(remote_addr) = err.remote_addr() {
+                        eprint!("[client {remote_addr}] ");
+                    }
+
                     eprintln!("Error accepting connection: {}", err);
                 }
             }

--- a/examples/http-stream.rs
+++ b/examples/http-stream.rs
@@ -1,4 +1,4 @@
-use futures_util::stream::StreamExt;
+use futures_util::stream::{StreamExt, TryStreamExt};
 use hyper::server::accept;
 use hyper::server::conn::AddrIncoming;
 use hyper::service::{make_service_fn, service_fn};
@@ -22,14 +22,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     // This uses a filter to handle errors with connecting
-    let incoming = TlsListener::new(tls_acceptor(), AddrIncoming::bind(&addr)?).filter(|conn| {
-        if let Err(err) = conn {
-            eprintln!("Error: {:?}", err);
-            ready(false)
-        } else {
-            ready(true)
-        }
-    });
+    let incoming = TlsListener::new(tls_acceptor(), AddrIncoming::bind(&addr)?)
+        .filter(|conn| {
+            if let Err(err) = conn {
+                eprintln!("Error: {:?}", err);
+                ready(false)
+            } else {
+                ready(true)
+            }
+        })
+        .map_ok(|(conn, _remote_addr)| conn);
 
     let server = Server::builder(accept::from_stream(incoming)).serve(new_svc);
     server.await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,7 @@ pub struct Builder<T> {
 
 /// Wraps errors from either the listener or the TLS Acceptor
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error<LE: std::error::Error, TE: std::error::Error> {
     /// An error that arose from the listener ([AsyncAccept::Error])
     #[error("{0}")]
@@ -149,6 +150,11 @@ pub enum Error<LE: std::error::Error, TE: std::error::Error> {
     /// An error that occurred during the TLS accept handshake
     #[error("{0}")]
     TlsAcceptError(#[source] TE),
+    // TODO: is there any way we could include thee original connection, or maybe some
+    // info about it here?
+    /// The TLS handshake timed out
+    #[error("Timeout during TLS handshake")]
+    HandshakeTimeout(),
 }
 
 impl<A: AsyncAccept, T> TlsListener<A, T>
@@ -219,16 +225,12 @@ where
             }
         }
 
-        loop {
-            return match this.waiting.poll_next_unpin(cx) {
-                Poll::Ready(Some(Ok(conn))) => {
-                    Poll::Ready(Some(conn.map_err(Error::TlsAcceptError)))
-                }
-                // The handshake timed out, try getting another connection from the
-                // queue
-                Poll::Ready(Some(Err(_))) => continue,
-                _ => Poll::Pending,
-            };
+        match this.waiting.poll_next_unpin(cx) {
+            Poll::Ready(Some(Ok(conn))) => Poll::Ready(Some(conn.map_err(Error::TlsAcceptError))),
+            // The handshake timed out, try getting another connection from the
+            // queue
+            Poll::Ready(Some(Err(_))) => Poll::Ready(Some(Err(Error::HandshakeTimeout()))),
+            _ => Poll::Pending,
         }
     }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -10,13 +10,14 @@ use tokio::net::{UnixListener, UnixStream};
 impl AsyncAccept for TcpListener {
     type Connection = TcpStream;
     type Error = io::Error;
+    type Address = std::net::SocketAddr;
 
     fn poll_accept(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Self::Connection, Self::Error>>> {
+    ) -> Poll<Option<Result<(Self::Connection, Self::Address), Self::Error>>> {
         match (*self).poll_accept(cx) {
-            Poll::Ready(Ok((stream, _))) => Poll::Ready(Some(Ok(stream))),
+            Poll::Ready(Ok((stream, remote_addr))) => Poll::Ready(Some(Ok((stream, remote_addr)))),
             Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
             Poll::Pending => Poll::Pending,
         }
@@ -28,13 +29,14 @@ impl AsyncAccept for TcpListener {
 impl AsyncAccept for UnixListener {
     type Connection = UnixStream;
     type Error = io::Error;
+    type Address = tokio::net::unix::SocketAddr;
 
     fn poll_accept(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Self::Connection, Self::Error>>> {
+    ) -> Poll<Option<Result<(Self::Connection, Self::Address), Self::Error>>> {
         match (*self).poll_accept(cx) {
-            Poll::Ready(Ok((stream, _))) => Poll::Ready(Some(Ok(stream))),
+            Poll::Ready(Ok((stream, remote_addr))) => Poll::Ready(Some(Ok((stream, remote_addr)))),
             Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
             Poll::Pending => Poll::Pending,
         }

--- a/tests/helper/mod.rs
+++ b/tests/helper/mod.rs
@@ -18,7 +18,7 @@ pub fn setup_echo() -> (MockConnect, JoinHandle<()>) {
     let (connector, listener) = setup();
 
     let handle = tokio::spawn(listener.for_each_concurrent(None, |s| async {
-        let (mut reader, mut writer) = split(s.expect("Unexpected error"));
+        let (mut reader, mut writer) = split(s.expect("Unexpected error").0);
         copy(&mut reader, &mut writer)
             .await
             .expect("Failed to copy");


### PR DESCRIPTION
This PR incorporates #37 and also changes `TlsListener` to report the remote address, both upon successfully accepting a connection and when TLS negotiation fails or times out.

This doesn't quite do what I wanted in #36, which as you said in https://github.com/tmccombs/tls-listener/issues/36#issuecomment-1728939647 is impossible, so reporting the remote address seems like the next best thing.

Unresolved issue: now `Error` has *three* type parameters. It's pretty messy. I could bring it back down to two by using the `AsyncAccept` and `AsyncTls` implementations as the type parameters instead (e.g. `Error<TcpListener, TlsAcceptor>`), but then the `impl Debug` can't be `derive`d because it will get the wrong bounds (see https://github.com/rust-lang/rust/issues/26925). This can be worked around by hand-writing `impl Debug for Error` (yuck) or by using a proc-macro crate like [educe](https://crates.io/crates/educe), [derivative](https://crates.io/crates/derivative), or [impl-tools](https://crates.io/crates/impl-tools) (which adds a proc-macro dependency, although you already have several). What do you think?

This contains breaking changes in addition to those in #37, namely:

* The enum variant `Error::ListenerError` is now struct-like instead of tuple-like, and is `non_exhaustive` like the enum itself.
* `Error` now has three type parameters, not two, as mentioned above.
* `TlsListener::accept` and `<TlsListener as Stream>::next` yields a tuple of (connection, remote address), not just the connection.
* `AsyncAccept` now has an associated type `Address`, which `poll_accept` must now return along with the accepted connection.