### PR TITLE
feat!: Remove until & remove option from accept

### DIFF
--- a/examples/echo-threads.rs
+++ b/examples/echo-threads.rs
@@ -1,6 +1,6 @@
 use futures_util::StreamExt;
 use std::net::SocketAddr;
-use tls_listener::{AsyncAccept, SpawningHandshakes, TlsListener};
+use tls_listener::{SpawningHandshakes, TlsListener};
 use tokio::io::{copy, split};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::signal::ctrl_c;
@@ -27,9 +27,10 @@ async fn handle_stream(stream: TlsStream<TcpStream>, _remote_addr: SocketAddr) {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr: SocketAddr = ([127, 0, 0, 1], 3000).into();
 
-    let listener = TcpListener::bind(&addr).await?.until(ctrl_c());
+    let listener = TcpListener::bind(&addr).await?;
 
     TlsListener::new(SpawningHandshakes(tls_acceptor()), listener)
+        .take_until(ctrl_c())
         .for_each_concurrent(None, |s| async {
             match s {
                 Ok((stream, remote_addr)) => {

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -1,6 +1,6 @@
 use futures_util::StreamExt;
 use std::net::SocketAddr;
-use tls_listener::{AsyncAccept, TlsListener};
+use tls_listener::TlsListener;
 use tokio::io::{copy, split};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::signal::ctrl_c;
@@ -36,9 +36,10 @@ async fn handle_stream(stream: TlsStream<TcpStream>, _remote_addr: SocketAddr) {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr: SocketAddr = ([127, 0, 0, 1], 3000).into();
 
-    let listener = TcpListener::bind(&addr).await?.until(ctrl_c());
+    let listener = TcpListener::bind(&addr).await?;
 
     TlsListener::new(tls_acceptor(), listener)
+        .take_until(ctrl_c())
         .for_each_concurrent(None, |s| async {
             match s {
                 Ok((stream, remote_addr)) => {

--- a/examples/http-change-certificate.rs
+++ b/examples/http-change-certificate.rs
@@ -31,7 +31,7 @@ async fn main() {
     loop {
         tokio::select! {
             conn = listener.accept() => {
-                match conn.expect("Tls listener stream should be infinite") {
+                match conn {
                     Ok((conn, remote_addr)) => {
                         let http = http.clone();
                         let tx = tx.clone();

--- a/examples/http.rs
+++ b/examples/http.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // We start a loop to continuously accept incoming connections
     loop {
-        match listener.accept().await.unwrap() {
+        match listener.accept().await {
             Ok((stream, _)) => {
                 let io = TokioIo::new(stream);
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -15,10 +15,10 @@ impl AsyncAccept for TcpListener {
     fn poll_accept(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<(Self::Connection, Self::Address), Self::Error>>> {
+    ) -> Poll<Result<(Self::Connection, Self::Address), Self::Error>> {
         match (*self).poll_accept(cx) {
-            Poll::Ready(Ok(conn)) => Poll::Ready(Some(Ok(conn))),
-            Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
+            Poll::Ready(Ok(conn)) => Poll::Ready(Ok(conn)),
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
             Poll::Pending => Poll::Pending,
         }
     }
@@ -34,10 +34,10 @@ impl AsyncAccept for UnixListener {
     fn poll_accept(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<(Self::Connection, Self::Address), Self::Error>>> {
+    ) -> Poll<Result<(Self::Connection, Self::Address), Self::Error>> {
         match (*self).poll_accept(cx) {
-            Poll::Ready(Ok(conn)) => Poll::Ready(Some(Ok(conn))),
-            Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
+            Poll::Ready(Ok(conn)) => Poll::Ready(Ok(conn)),
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
             Poll::Pending => Poll::Pending,
         }
     }

--- a/tests/helper/mocks.rs
+++ b/tests/helper/mocks.rs
@@ -70,8 +70,8 @@ impl AsyncAccept for MockAccept {
     type Error = io::Error;
     type Address = MockAddress;
 
-    fn poll_accept(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<ConnResult>> {
-        Pin::into_inner(self).chan.poll_recv(cx)
+    fn poll_accept(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<ConnResult> {
+        Pin::into_inner(self).chan.poll_recv(cx).map(|c| c.unwrap())
     }
 }
 

--- a/tests/helper/mod.rs
+++ b/tests/helper/mod.rs
@@ -1,6 +1,7 @@
 use futures_util::StreamExt;
 use tls_listener::TlsListener;
 use tokio::io::{copy, split};
+use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
 mod asserts;
@@ -14,14 +15,18 @@ pub fn setup() -> (MockConnect, TlsListener<MockAccept, MockTls>) {
     (connect, TlsListener::new(MockTls, accept))
 }
 
-pub fn setup_echo() -> (MockConnect, JoinHandle<()>) {
+pub fn setup_echo(end: oneshot::Receiver<()>) -> (MockConnect, JoinHandle<()>) {
     let (connector, listener) = setup();
 
-    let handle = tokio::spawn(listener.for_each_concurrent(None, |s| async {
-        let (mut reader, mut writer) = split(s.expect("Unexpected error").0);
-        copy(&mut reader, &mut writer)
-            .await
-            .expect("Failed to copy");
-    }));
+    let handle = tokio::spawn(
+        listener
+            .take_until(end)
+            .for_each_concurrent(None, |s| async {
+                let (mut reader, mut writer) = split(s.expect("Unexpected error").0);
+                copy(&mut reader, &mut writer)
+                    .await
+                    .expect("Failed to copy");
+            }),
+    );
     (connector, handle)
 }


### PR DESCRIPTION
Accepting a connection in all cases that I am aware of is an operation that either succeeds or gives an error. It doesn't really make sense for it to return an `Option<Result<...>>`. Changing the return type to just `Result<..>` simplifies not only this library, but also any additional implementations of `AsyncAccept` and any usages of `TlsListener.accept()`.

The one use case, where we needed an `Option` was if the `AsyncAccept` trait was configured to end when another future finished first. However, this functionality is already (mostly) available with the `StreamExt::take_until` method.

I will note that the behavior with take_until is slightly different. With the previous `Until` impementation, if a tcp connection had been successfully established, but the TLS handshake hadn't been established yet, when the finalization future completed, then we would continue processing that connection.

However, with `StreamExt::take_until`, such
a connection would be dropped, since it checks the finalizaition future before polling the stream. I hope that in the vast majority of cases this doesn't really matter, or is a better behavior.

BREAKING CHANGE: remove `until` from AsyncAccept trait. Use
  `StreamExt.take_until` on the TlsListener instead.
BREAKING CHANGE: `accept` fn on AsyncAccept trait no longer returns an
  Option
BREAKING CHANGE: `accept` fn on TlsListener no longer returns an Option