### PR TITLE
Allow using tokio-rustls 0.26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tls-listener"
 description = "wrap incoming Stream of connections in TLS"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Thayne McCombs <astrothayne@gmail.com>"]
 repository = "https://github.com/tmccombs/tls-listener"
 edition = "2018"
@@ -22,7 +22,7 @@ pin-project-lite = "0.2.13"
 thiserror = "1.0.30"
 tokio = { version = "1.0", features = ["time"] }
 tokio-native-tls = { version = "0.3.0", optional = true }
-tokio-rustls = { version = "0.26.0", optional = true }
+tokio-rustls = { version = ">=0.25.0,<0.27", optional = true }
 tokio-openssl = { version = "0.6.3", optional = true }
 openssl_impl = { package = "openssl", version = "0.10.32", optional = true }
 


### PR DESCRIPTION
And continue supporting 0.25

Fixes: #44