### PR TITLE
Stop automatically pulling in aws-lc as a dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ license = "Apache-2.0"
 [features]
 default = ["tokio-net"]
 rustls = ["tokio-rustls"]
+rustls-aws-lc = ["rustls", "tokio-rustls/aws-lc-rs"]
+rustls-fips = ["rustls-aws-lc", "tokio-rustls/fips"]
+rustls-ring = ["rustls", "tokio-rustls/ring"]
 native-tls = ["tokio-native-tls"]
 openssl = ["tokio-openssl", "openssl_impl"]
 rt = ["tokio/rt"]
@@ -22,7 +25,7 @@ pin-project-lite = "0.2.13"
 thiserror = "1.0.30"
 tokio = { version = "1.0", features = ["time"] }
 tokio-native-tls = { version = "0.3.0", optional = true }
-tokio-rustls = { version = ">=0.25.0,<0.27", optional = true }
+tokio-rustls = { version = ">=0.25.0,<0.27", default-features = false, optional = true }
 tokio-openssl = { version = "0.6.3", optional = true }
 openssl_impl = { package = "openssl", version = "0.10.32", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,11 @@ license = "Apache-2.0"
 
 [features]
 default = ["tokio-net"]
-rustls = ["tokio-rustls"]
-rustls-aws-lc = ["rustls", "tokio-rustls/aws-lc-rs"]
+rustls-core = ["tokio-rustls"]
+rustls-aws-lc = ["rustls-core", "tokio-rustls/aws-lc-rs"]
 rustls-fips = ["rustls-aws-lc", "tokio-rustls/fips"]
-rustls-ring = ["rustls", "tokio-rustls/ring"]
+rustls-ring = ["rustls-core", "tokio-rustls/ring"]
+rustls = ["rustls-aws-lc", "tokio-rustls/default"]
 native-tls = ["tokio-native-tls"]
 openssl = ["tokio-openssl", "openssl_impl"]
 rt = ["tokio/rt"]
@@ -63,5 +64,14 @@ name = "http-change-certificate"
 path = "examples/http-change-certificate.rs"
 
 [package.metadata.docs.rs]
-features = ["rustls", "native-tls", "openssl", "rt"]
+features = [
+    "rustls-core",
+    "rustls",
+    "rustls-aws-lc",
+    "rustls-fips",
+    "rustls-ring",
+    "native-tls",
+    "openssl",
+    "rt"
+]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -13,39 +13,11 @@ It can be used to easily create a `Stream` of TLS connections from a listening s
 
 See examples for examples of usage.
 
-You must enable either one of the `rustls[-xyz]` (more details below), `native-tls`, or `openssl`
+You must enable either one of the `rustls` (more details below), `native-tls`, or `openssl`
 features depending on which implementation you would like to use.
 
-When enabling the `rustls` feature, the `rustls` crate will be added as a dependency through
-the `tokio-rustls` crate without any
-[cryptography providers](https://docs.rs/rustls/latest/rustls/#cryptography-providers)
-included by default. To include one, do either of the following:
-
-1. Enable at least one of the additional `rustls-aws-lc`, `rustls-fips`, or `rustls-ring` features.
-   By doing this, you can also remove the `rustls` feature flag since it will be enabled
-   automatically by any of the `rustls-xyz` features.
-
-   ```toml
-   # Replace `rustls-xyz` with one of the features mentioned above.
-   tls-listener = { version = "x", features = ["rustls-xyz"] }
-   ```
-
-   These features will enable their relevant [`rustls` features](https://docs.rs/rustls/latest/rustls/#crate-features).
-
-1. Keep the `rustls` feature flag, but directly add the [`rustls`](https://crates.io/crates/rustls)
-   and/or [`tokio-rustls`](https://crates.io/crates/tokio-rustls) crates to your project's 
-   dependencies and enable your preferred flags on them instead of adding additional flags on
-   this crate (`tls-listener`).
-
-   ```toml
-   # Replace `xyz` with one of the features mentioned in the crate's documentation.
-   # for example: `aws-lc-rc`, `fips` or `ring`
-   rustls = { version = "x", default-features = false, features = ["xyz"]}
-   # And/or
-   tokio-rustls = { version = "x", default-features = false, features = ["xyz"]}
-   ```
-
-   You can also enable the default features by removing `default-features = false`, which will
-   enable the [AWS-LC crypto provider](https://github.com/aws/aws-lc-rs). However, their
-   default features are not enable by `tls-listener` because doing so will make disabling
-   them very hard for dependent crates.
+When enabling the `rustls` feature, the `rustls` crate will be added as a dependency along
+with it's default [cryptography provider](https://docs.rs/rustls/latest/rustls/#cryptography-providers).
+To avoid this behaviour and use other cryptography providers, the `rustls-core` feature can be used instead.
+Additional feature flags for other [rustls built-in cryptography providers](https://docs.rs/rustls/latest/rustls/#built-in-providers) are also available:
+`rustls-aws-lc` (default), `rustls-fips` and `rustls-ring`

--- a/README.md
+++ b/README.md
@@ -13,5 +13,39 @@ It can be used to easily create a `Stream` of TLS connections from a listening s
 
 See examples for examples of usage.
 
-You must enable either one of the `rustls`, `native-tls`, or `openssl` features depending on which implementation you
-would like to use.
+You must enable either one of the `rustls[-xyz]` (more details below), `native-tls`, or `openssl`
+features depending on which implementation you would like to use.
+
+When enabling the `rustls` feature, the `rustls` crate will be added as a dependency through
+the `tokio-rustls` crate without any
+[cryptography providers](https://docs.rs/rustls/latest/rustls/#cryptography-providers)
+included by default. To include one, do either of the following:
+
+1. Enable at least one of the additional `rustls-aws-lc`, `rustls-fips`, or `rustls-ring` features.
+   By doing this, you can also remove the `rustls` feature flag since it will be enabled
+   automatically by any of the `rustls-xyz` features.
+
+   ```toml
+   # Replace `rustls-xyz` with one of the features mentioned above.
+   tls-listener = { version = "x", features = ["rustls-xyz"] }
+   ```
+
+   These features will enable their relevant [`rustls` features](https://docs.rs/rustls/latest/rustls/#crate-features).
+
+1. Keep the `rustls` feature flag, but directly add the [`rustls`](https://crates.io/crates/rustls)
+   and/or [`tokio-rustls`](https://crates.io/crates/tokio-rustls) crates to your project's 
+   dependencies and enable your preferred flags on them instead of adding additional flags on
+   this crate (`tls-listener`).
+
+   ```toml
+   # Replace `xyz` with one of the features mentioned in the crate's documentation.
+   # for example: `aws-lc-rc`, `fips` or `ring`
+   rustls = { version = "x", default-features = false, features = ["xyz"]}
+   # And/or
+   tokio-rustls = { version = "x", default-features = false, features = ["xyz"]}
+   ```
+
+   You can also enable the default features by removing `default-features = false`, which will
+   enable the [AWS-LC crypto provider](https://github.com/aws/aws-lc-rs). However, their
+   default features are not enable by `tls-listener` because doing so will make disabling
+   them very hard for dependent crates.

--- a/examples/echo-threads.rs
+++ b/examples/echo-threads.rs
@@ -4,9 +4,9 @@ use tls_listener::{SpawningHandshakes, TlsListener};
 use tokio::io::{copy, split};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::signal::ctrl_c;
-#[cfg(all(feature = "native-tls", not(feature = "rustls")))]
+#[cfg(all(feature = "native-tls", not(feature = "rustls-core")))]
 use tokio_native_tls::TlsStream;
-#[cfg(feature = "rustls")]
+#[cfg(feature = "rustls-core")]
 use tokio_rustls::server::TlsStream;
 
 mod tls_config;

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -7,15 +7,15 @@ use tokio::signal::ctrl_c;
 
 #[cfg(all(
     feature = "native-tls",
-    not(any(feature = "rustls", feature = "openssl"))
+    not(any(feature = "rustls-core", feature = "openssl"))
 ))]
 use tokio_native_tls::TlsStream;
 #[cfg(all(
     feature = "openssl",
-    not(any(feature = "rustls", feature = "native-tls"))
+    not(any(feature = "rustls-core", feature = "native-tls"))
 ))]
 use tokio_openssl::SslStream as TlsStream;
-#[cfg(feature = "rustls")]
+#[cfg(feature = "rustls-core")]
 use tokio_rustls::server::TlsStream;
 
 mod tls_config;

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -56,7 +56,7 @@ def build_examples():
             "build",
             "--examples",
             "--features",
-            "rustls-aws-lc,rt,tokio/rt-multi-thread",
+            "rustls,rt,tokio/rt-multi-thread",
         ]
     )
     proc.check_returncode()

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -56,7 +56,7 @@ def build_examples():
             "build",
             "--examples",
             "--features",
-            "rustls,rt,tokio/rt-multi-thread",
+            "rustls-aws-lc,rt,tokio/rt-multi-thread",
         ]
     )
     proc.check_returncode()

--- a/examples/tls_config/mod.rs
+++ b/examples/tls_config/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "rustls")]
+#[cfg(feature = "rustls-core")]
 mod config {
     use std::sync::Arc;
     use tokio_rustls::rustls::{
@@ -39,7 +39,7 @@ mod config {
 
 #[cfg(all(
     feature = "native-tls",
-    not(any(feature = "rustls", feature = "openssl"))
+    not(any(feature = "rustls-core", feature = "openssl"))
 ))]
 mod config {
     use tokio_native_tls::native_tls::{Identity, TlsAcceptor};
@@ -65,7 +65,7 @@ mod config {
 
 #[cfg(all(
     feature = "openssl",
-    not(any(feature = "rustls", feature = "native-tls"))
+    not(any(feature = "rustls-core", feature = "native-tls"))
 ))]
 mod config {
     use openssl_impl::ssl::{SslContext, SslFiletype, SslMethod};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ use tokio::time::{timeout, Timeout};
 pub use tokio_native_tls as native_tls;
 #[cfg(feature = "openssl")]
 pub use tokio_openssl as openssl;
-#[cfg(feature = "rustls")]
+#[cfg(feature = "rustls-core")]
 pub use tokio_rustls as rustls;
 
 #[cfg(feature = "rt")]
@@ -270,8 +270,8 @@ where
     }
 }
 
-#[cfg(feature = "rustls")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rustls")))]
+#[cfg(feature = "rustls-core")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rustls-core")))]
 impl<C: AsyncRead + AsyncWrite + Unpin> AsyncTls<C> for tokio_rustls::TlsAcceptor {
     type Stream = tokio_rustls::server::TlsStream<C>;
     type Error = std::io::Error;


### PR DESCRIPTION
This fixes an issue I had when trying to cross-compile my project. `aws-lc` would refuse to compile due to some problems in their build system. Although it is not a `tls-listener` issue, allowing dependent crates to fine-tine features of nested dependencies is reasonable.